### PR TITLE
Add CocoaPods support

### DIFF
--- a/BambuserPlayerSDK.podspec
+++ b/BambuserPlayerSDK.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name             = 'BambuserPlayerSDK'
+  s.version          = '1.5.0'
+  s.summary          = 'BambuserPlayerSDK provides a player for live streaming content.'
+  s.description      = <<-DESC
+                        BambuserPlayerSDK allows you to integrate a player for live streaming content into your iOS application.
+                        DESC
+  s.homepage         = 'https://www.bambuser.com/'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'Bambuser' => 'support@bambuser.com' }
+  s.source           = { :http => 'https://cdn.liveshopping.bambuser.com/public/download/BambuserPlayerSDK-1.5.0-release.xcframework.zip' }
+  s.vendored_frameworks = "BambuserPlayerSDK.xcframework"
+  s.platform         = :ios, '14.0'
+
+  s.dependency 'Firebase/Auth'
+  s.dependency 'Firebase/Firestore'
+end

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ After installing the SDK, you must import `BambuserPlayerSDK` in every file wher
 
 ### CocoaPods
 
-This SDK does not support CocoaPods.
+```
+pod 'BambuserPlayerSDK', '~> 1.5.0'
+```
 
 ### Carthages
 


### PR DESCRIPTION
## Description
This PR adds a `podspec` file to enable CocoaPods support for the BambuserPlayerSDK.

The ReadMe has been updated as well with installation instructions for using the pod.

Closes #13 

## Next steps

- [ ] Need to correctly include resources in the podspec

- [ ] Add a license
  - CocoaPods require a license to publish, this is easily done by following these docs https://guides.cocoapods.org/making/making-a-cocoapod.html#the-pod-files

https://github.com/bambuser/BambuserPlayerSDK-iOS/blob/b1a77232824e47bab3293fe0b6aae903854f109d/BambuserPlayerSDK.podspec#L9

- [ ] Publish the release
  - Publish to CocoaPods with a simple command https://guides.cocoapods.org/making/making-a-cocoapod.html#release 

```bash
pod trunk push BambuserPlayerSDK.podspec
```