### PR TITLE
Allow future versions of Firebase sdks

### DIFF
--- a/BambuserPlayerSDK.podspec
+++ b/BambuserPlayerSDK.podspec
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0'
   s.swift_version    = '5.9'
 
-  s.dependency 'Firebase/Firestore', '10.18.0'
-  s.dependency 'Firebase/Auth', '10.18.0'
+  s.dependency 'Firebase/Firestore', '~> 10.18'
+  s.dependency 'Firebase/Auth', '~> 10.18'
 
   s.prepare_command = <<-CMD
   git clone https://github.com/bambuser/BambuserPlayerSDK-iOS ResourcesRepo


### PR DESCRIPTION
The current podspec file specifies Firebase dependencies strictly with version `10.18.0` however the swift package manager version specifies a minimum version of `10.18.0`. This pr updates the podspec to support the same minimum version standard.

https://github.com/bambuser/BambuserPlayerSDK-iOS/blob/9f845ba01e51af59e1066f3f747f832ed603a7b4/Package.swift#L19