### PR TITLE
Bump dependency versions

### DIFF
--- a/BambuserPlayerSDK.podspec
+++ b/BambuserPlayerSDK.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   s.swift_version    = '5.9'
 
   # Dependencies for Firebase modules
-  s.dependency 'Firebase/Firestore', '~> 10.18'
-  s.dependency 'Firebase/Auth', '~> 10.18'
+  s.dependency 'Firebase/Firestore', '~> 11.2'
+  s.dependency 'Firebase/Auth', '~> 11.2'
 
   # Resource bundle for BambuserPlayerBundle
   s.resource_bundles = {


### PR DESCRIPTION
With the yearly iOS updates comes a new Xcode 16. Some native issues have been resolved in the new Firebase 11.2 sdks. 

This pr bumps the required sdk versions to 11.2. This should resolve the React Native build issues using the Bambuser Pod.